### PR TITLE
fix: detect wrong-version runtime Python and provision via uv

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 
 DEFAULT_VENV = Path.home() / ".agentfeeds" / "runtime-venv"
+# Keep in sync with pyproject.toml `requires-python`.
+MIN_PYTHON = (3, 11)
 
 
 def venv_python(path: Path) -> Path:
@@ -20,27 +22,76 @@ def venv_python(path: Path) -> Path:
     return path / "bin" / "python"
 
 
+def python_version(executable: Path) -> tuple[int, int] | None:
+    if not executable.exists():
+        return None
+    try:
+        out = subprocess.run(
+            [
+                str(executable),
+                "-c",
+                "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        major, minor = out.split(".")
+        return (int(major), int(minor))
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Install Agent Feeds skill runtime")
     parser.add_argument("--venv", type=Path, default=DEFAULT_VENV, help="runtime virtualenv path")
+    parser.add_argument(
+        "--python",
+        default=None,
+        help=(
+            "Python interpreter spec passed to `uv venv --python` (e.g. 3.12, "
+            "/usr/local/bin/python3.12). Defaults to the running interpreter when it "
+            f"satisfies >={MIN_PYTHON[0]}.{MIN_PYTHON[1]}, otherwise uv provisions a "
+            "compatible Python."
+        ),
+    )
     return parser
 
 
-def create_venv(path: Path) -> None:
-    if venv_python(path).exists():
+def create_venv(path: Path, python_override: str | None) -> None:
+    existing = python_version(venv_python(path))
+    if existing is not None and python_override is None and existing >= MIN_PYTHON:
         return
-    try:
+    if path.exists():
+        shutil.rmtree(path)
+
+    uv = shutil.which("uv")
+    needed = f">={MIN_PYTHON[0]}.{MIN_PYTHON[1]}"
+
+    if python_override is not None:
+        if not uv:
+            raise RuntimeError(
+                "--python requires uv to provision the venv; install uv "
+                "(https://docs.astral.sh/uv/)."
+            )
+        subprocess.run([uv, "venv", "--python", python_override, str(path)], check=True)
+        return
+
+    if sys.version_info[:2] >= MIN_PYTHON:
         venv.EnvBuilder(with_pip=True).create(path)
         return
-    except Exception:
-        if path.exists():
-            import shutil as _shutil
 
-            _shutil.rmtree(path)
-        uv = shutil.which("uv")
-        if not uv:
-            raise
-        subprocess.run([uv, "venv", "--python", sys.executable, str(path)], check=True)
+    if not uv:
+        raise RuntimeError(
+            f"Agent Feeds requires Python {needed}, but {sys.executable} reports "
+            f"{sys.version_info[0]}.{sys.version_info[1]}. Install uv "
+            "(https://docs.astral.sh/uv/), pass --python <interpreter>, or run "
+            "setup.py with a newer python3."
+        )
+    subprocess.run(
+        [uv, "venv", "--python", f"{MIN_PYTHON[0]}.{MIN_PYTHON[1]}", str(path)],
+        check=True,
+    )
 
 
 def install_runtime(python: Path, root: Path) -> None:
@@ -65,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(__file__).resolve().parents[1]
     venv_path = args.venv.expanduser()
     venv_path.parent.mkdir(parents=True, exist_ok=True)
-    create_venv(venv_path)
+    create_venv(venv_path, args.python)
     python = venv_python(venv_path)
     install_runtime(python, root)
     print(f"installed Agent Feeds runtime: {venv_path}")


### PR DESCRIPTION
Closes #9.

## Summary
- `setup.py` previously inherited `sys.executable` into `venv.EnvBuilder` unconditionally, so a host with `python3` < 3.11 on PATH silently built a 3.10 venv and the failure surfaced later as a confusing `requires-python` error from pip.
- The existing `uv` fallback only fired when `EnvBuilder` itself raised, and it passed `sys.executable` to `uv venv --python`, so a too-old interpreter could never self-correct.
- Now: detect existing venv Python and rebuild when below `MIN_PYTHON`; when the running interpreter is too old, drive `uv venv --python 3.11`; expose a `--python` flag for explicit override; fail fast with an actionable message when both `uv` is absent and `python3` is too old.

## Test plan
Manually exercised four scenarios with `--venv` pointed at a temp path:

- [x] `/path/to/python3.10 scripts/setup.py --venv $TMP` → falls through to `uv`, ends up with Python 3.11.15
- [x] Re-run with a stale 3.10 venv already at `--venv` → detected and rebuilt as 3.11.15
- [x] `--python 3.12` override → 3.12.13 venv via `uv`
- [x] Re-run on an existing 3.11 venv → skips create, just re-runs the editable install

Also ran the test suite: my branch has the same 9 pre-existing failures (catalog schema drift, adapter unit tests) as `main` — no new regressions, and 50 tests pass. Those failures are out of scope for this fix.

## Notes
- `MIN_PYTHON = (3, 11)` is hardcoded with a comment to keep it in sync with `pyproject.toml`. Reading `requires-python` dynamically would need `tomllib` (3.11+) or a regex parser, both of which felt like more code than warranted for a single tuple.