### PR TITLE
docs: fix release trust blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## skill-v0.1.2 — 2026-05-04
+
+Release: https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.2
+
+Highlights:
+
+- `setup.py` detects when `python3` on PATH is older than 3.11 and provisions a compatible interpreter via `uv`.
+- Added `--python` setup override and rebuilds stale runtime virtualenvs on re-run.
+- Bundled `dev/github-prs` and `dev/github-issues` templates now ship with `auth_service: github` / `auth: bearer_token`, so private repos work with a token at `~/.agentfeeds/secrets/github_token.txt`.
+
+Validation:
+
+- 50 unit tests pass; 9 pre-existing failures are unchanged from v0.1.1.
+- Bundle manually inspected to confirm both fixes ship.
+
+## skill-v0.1.1 — 2026-05
+
+Initial public skill-bundle release for AgentFeeds.
+
+Included:
+
+- Agent-facing `SKILL.md` and references.
+- Bundled Python runtime and CLI scripts.
+- Frozen built-in template catalog fallback.
+- Background polling installer for launchd/cron.
+- Built-in templates for macOS personal sources, local files/directories/Markdown/Git state, RSS, GitHub, ICS calendars, weather, exchange rates, and approved local commands.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ AgentFeeds moves that work into background refresh plus an agent-facing read pat
 
 Agents need feeds, not just memory. Memory remembers stable facts. AgentFeeds keeps fresh context available.
 
+## How AgentFeeds Is Different
+
+AgentFeeds is intentionally narrow: it is a refreshable local state layer for agents, not another all-purpose memory system.
+
+- **Not memory:** durable preferences and identity still belong in memory; volatile state stays in timestamped feeds.
+- **Not RAG:** streams are subscribed, structured, and refreshed on a schedule instead of being only semantically searched after the fact.
+- **Not an MCP replacement:** MCP exposes tools; AgentFeeds keeps tool/API/local-source results warm on disk so an agent can inspect state before deciding what to call.
+- **Not a dashboard:** humans can inspect the files, but the primary reader is the agent via `brief`, `search`, and `streams read`.
+
+The practical promise is simple: before your personal agent searches the web, scans skills, re-fetches APIs, or asks you to repeat context, it can check what fresh local streams already exist.
+
+## Trust And Safety Model
+
+AgentFeeds is designed for local-first, inspectable operation:
+
+- Stream state is stored as JSON under `~/.agentfeeds/`; operators can audit what the agent sees.
+- Built-in public/API templates use explicit parameters and schemas, with a frozen catalog bundled for first-run reliability.
+- Local command templates run without a shell, with argv arrays, timeouts, and output-size limits.
+- New `local_command` templates are safety-gated: they do not execute until the operator approves the exact template and command digest interactively.
+- Agents are instructed to use `subscribe`, `refresh`, and `streams read` instead of hand-writing state files.
+- Secrets should be referenced through AgentFeeds secret slots, not committed into template YAML.
+
 ## Try It With Your Agent
 
 After installing the skill, you should not need to operate AgentFeeds directly. Ask your agent for outcomes in natural language:
@@ -71,19 +93,35 @@ With AgentFeeds, the agent first checks the local stream brief/search/read path,
 
 ![AgentFeeds interactive session demo](assets/agentfeeds-demo.gif)
 
+A healthy session-start brief looks like this:
+
+```xml
+<agentfeeds>
+Available local streams by group:
+- calendar: work-calendar
+- mac: reminders-pending, mail-unread
+- dev: github-notifications, project-git-status
+- news: openai-com, anthropic-com
+</agentfeeds>
+```
+
+The brief is intentionally compact. It tells the agent what fresh local context exists, then the agent reads only relevant streams with `search` or `streams read`.
+
 ## Install The Skill
 
 Download the latest skill bundle from the bundle release and unpack it into your agent's skills directory:
 
 ```text
-https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.1
+https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.2
 ```
 
 The release asset is:
 
 ```text
-agentfeeds-skill-v0.1.1.zip
+agentfeeds-skill-v0.1.2.zip
 ```
+
+Release notes are tracked in [CHANGELOG.md](CHANGELOG.md) and on the [skill-v0.1.2 GitHub release](https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.2).
 
 The unpacked skill folder contains:
 
@@ -257,7 +295,7 @@ Restart Hermes after installation.
 This repo is the source tree for the skill. Release artifacts should be built as portable skill bundles:
 
 ```bash
-python3 scripts/bundle/build_skill_bundle.py --output dist/agentfeeds-skill-v0.1.1.zip
+python3 scripts/bundle/build_skill_bundle.py --output dist/agentfeeds-skill-v0.1.2.zip
 ```
 
 The bundle intentionally includes only the skill surface, frozen catalog snapshot, and runtime files needed by agents. Repo-only docs, tests, build outputs, and caches are excluded.
@@ -295,6 +333,8 @@ MCP is a tool interface. AgentFeeds is a local state substrate: background refre
 RSS is one template type. AgentFeeds also supports local files, GitHub releases/issues/PRs, ICS calendars, weather, exchange rates, and operator-approved local commands. The product is the subscription/state layer for agents, not a human feed UI.
 
 ## More Docs
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 See [docs/DEMO.md](docs/DEMO.md) for the demo transcript and talking points.
 

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,6 +1,6 @@
 # Agent Feeds Demo
 
-This is the short launch demo for Agent Feeds v0.1.1.
+This is the short launch demo for Agent Feeds v0.1.2.
 
 ## Narrative
 

--- a/docs/REGISTRY_SUBMISSION.md
+++ b/docs/REGISTRY_SUBMISSION.md
@@ -86,13 +86,13 @@ https://github.com/verkyyi/agentfeeds
 Release / install URL:
 
 ```text
-https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.1
+https://github.com/verkyyi/agentfeeds/releases/tag/skill-v0.1.2
 ```
 
 Release asset:
 
 ```text
-agentfeeds-skill-v0.1.1.zip
+agentfeeds-skill-v0.1.2.zip
 ```
 
 Demo asset:

--- a/docs/SHARING.md
+++ b/docs/SHARING.md
@@ -75,7 +75,7 @@ python3 scripts/agentfeeds.py admin templates test personal/status --json
 Title:
 
 ```text
-Agent Feeds v0.1.1: Local ambient context for personal agents
+Agent Feeds v0.1.2: Local ambient context for personal agents
 ```
 
 Body:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agentfeeds-skill"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
## Summary

- Update install and registry docs to point at `skill-v0.1.2` / `agentfeeds-skill-v0.1.2.zip`
- Add README sections explaining how AgentFeeds differs from memory/RAG/MCP/dashboards
- Add README trust/safety model covering local JSON state, frozen catalog, no-shell local commands, digest-gated approvals, and secrets handling
- Add a compact `<agentfeeds>` brief example and create `CHANGELOG.md`
- Sync `uv.lock` package version to `0.1.2`

## Test Plan

- `uv run pytest tests/test_host_agnostic_skill.py tests/test_catalog_validity.py -q`
- Verified GitHub release asset exists for `agentfeeds-skill-v0.1.2.zip`
- Verified no stale `skill-v0.1.1` install refs remain outside changelog history
