### PR TITLE
docs: make AgentFeeds brief more agent-directed

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ A healthy session-start brief looks like this:
 
 ```xml
 <agentfeeds>
-Available local streams by group:
+Fresh local context. Health: ok.
+Prefer relevant streams before web/API calls or asking again.
 - calendar: work-calendar
 - mac: reminders-pending, mail-unread
 - dev: github-notifications, project-git-status

--- a/scripts/lib/agentfeeds_runtime/commands.py
+++ b/scripts/lib/agentfeeds_runtime/commands.py
@@ -844,16 +844,18 @@ def _brief_entries(root: Path, max_streams: int, include_freshness: bool) -> tup
     return entries, len(rows) > max_streams
 
 
-def _brief_health_summary(health: dict) -> str | None:
+def _brief_health_summary(health: dict) -> str:
     summary = health["summary"]
     degraded = summary["stale"] or summary["missing"] or summary["error"]
     if not degraded:
-        return None
+        return "Fresh local context. Health: ok."
     parts = []
     for key in ("stale", "missing", "error"):
-        if summary[key]:
-            parts.append(f"{summary[key]} {key}")
-    return "Ambient health: degraded (" + ", ".join(parts) + ")"
+        count = summary[key]
+        if count:
+            label = "source" if count == 1 else "sources"
+            parts.append(f"{count} {label} {key}")
+    return "Fresh local context. Health: degraded (" + ", ".join(parts) + ")."
 
 
 def _brief_grouped_lines(entries: list[dict], include_freshness: bool) -> list[str]:
@@ -873,11 +875,11 @@ def _brief_grouped_lines(entries: list[dict], include_freshness: bool) -> list[s
 def render_brief(entries: list[dict], truncated: bool, include_freshness: bool, health: dict | None = None) -> str:
     lines = ["<agentfeeds>"]
     if health:
-        health_line = _brief_health_summary(health)
-        if health_line:
-            lines.append(health_line)
+        lines.append(_brief_health_summary(health))
+    else:
+        lines.append("Fresh local context.")
     if entries:
-        lines.append("Available local streams by group:")
+        lines.append("Prefer relevant streams before web/API calls or asking again.")
         lines.extend(_brief_grouped_lines(entries, include_freshness))
         if truncated:
             lines.append("- ...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,8 +199,9 @@ def test_cli_brief_outputs_compact_stable_prompt_context(tmp_path, capsys):
 
     assert cli.main(["--root", str(root), "brief"]) == 0
     out = capsys.readouterr().out
-    assert out.startswith("<agentfeeds>\nAvailable local streams by group:")
+    assert out.startswith("<agentfeeds>\nFresh local context. Health: ok.\nPrefer relevant streams before web/API calls or asking again.")
     assert "- local: project-notes-md" in out
+    assert "Available local streams by group" not in out
     assert "Background refresh is expected" not in out
     assert "last_updated" not in out
     assert "updated=" not in out


### PR DESCRIPTION
## Summary

- Update `agentfeeds brief` to use the compact, agent-directed wording:
  - `Fresh local context. Health: ...`
  - `Prefer relevant streams before web/API calls or asking again.`
- Keep stream grouping compact and host-neutral.
- Update README example and CLI tests to match the new canonical brief.

## Test Plan

- `python3 scripts/agentfeeds.py brief`
- `uv run pytest tests/test_cli.py tests/test_host_agnostic_skill.py tests/test_catalog_validity.py -q`
